### PR TITLE
!refactor: backport remove genesis persistence from state

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-//----------------------------------------------
+// ----------------------------------------------
 // byzantine failures
 
 // Byzantine node sends two different prevotes (nil and blockID) to the same validator
@@ -54,7 +54,9 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 			DiscardABCIResponses: false,
 		})
-		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+		state, err := sm.MakeGenesisState(genDoc)
+		require.NoError(t, err)
+		require.NoError(t, stateStore.Save(state))
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		defer os.RemoveAll(thisConfig.RootDir)
 		ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal
@@ -166,13 +168,13 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 			for i, peer := range peerList {
 				if i < len(peerList)/2 {
 					bcs.Logger.Info("Signed and pushed vote", "vote", prevote1, "peer", peer)
-					p2p.SendEnvelopeShim(peer, p2p.Envelope{ //nolint: staticcheck
+					p2p.SendEnvelopeShim(peer, p2p.Envelope{ // nolint: staticcheck
 						Message:   &cmtcons.Vote{Vote: prevote1.ToProto()},
 						ChannelID: VoteChannel,
 					}, bcs.Logger)
 				} else {
 					bcs.Logger.Info("Signed and pushed vote", "vote", prevote2, "peer", peer)
-					p2p.SendEnvelopeShim(peer, p2p.Envelope{ //nolint: staticcheck
+					p2p.SendEnvelopeShim(peer, p2p.Envelope{ // nolint: staticcheck
 						Message:   &cmtcons.Vote{Vote: prevote2.ToProto()},
 						ChannelID: VoteChannel,
 					}, bcs.Logger)
@@ -462,7 +464,7 @@ func TestByzantineConflictingProposalsWithPartition(t *testing.T) {
 	}
 }
 
-//-------------------------------
+// -------------------------------
 // byzantine consensus functions
 
 func byzantineDecideProposalFunc(t *testing.T, height int64, round int32, cs *State, sw *p2p.Switch) {
@@ -519,7 +521,7 @@ func sendProposalAndParts(
 	parts *types.PartSet,
 ) {
 	// proposal
-	p2p.SendEnvelopeShim(peer, p2p.Envelope{ //nolint: staticcheck
+	p2p.SendEnvelopeShim(peer, p2p.Envelope{ // nolint: staticcheck
 		ChannelID: DataChannel,
 		Message:   &cmtcons.Proposal{Proposal: *proposal.ToProto()},
 	}, cs.Logger)
@@ -531,7 +533,7 @@ func sendProposalAndParts(
 		if err != nil {
 			panic(err) // TODO: wbanfield better error handling
 		}
-		p2p.SendEnvelopeShim(peer, p2p.Envelope{ //nolint: staticcheck
+		p2p.SendEnvelopeShim(peer, p2p.Envelope{ // nolint: staticcheck
 			ChannelID: DataChannel,
 			Message: &cmtcons.BlockPart{
 				Height: height, // This tells peer that this part applies to us.
@@ -546,17 +548,17 @@ func sendProposalAndParts(
 	prevote, _ := cs.signVote(cmtproto.PrevoteType, blockHash, parts.Header())
 	precommit, _ := cs.signVote(cmtproto.PrecommitType, blockHash, parts.Header())
 	cs.mtx.Unlock()
-	p2p.SendEnvelopeShim(peer, p2p.Envelope{ //nolint: staticcheck
+	p2p.SendEnvelopeShim(peer, p2p.Envelope{ // nolint: staticcheck
 		ChannelID: VoteChannel,
 		Message:   &cmtcons.Vote{Vote: prevote.ToProto()},
 	}, cs.Logger)
-	p2p.SendEnvelopeShim(peer, p2p.Envelope{ //nolint: staticcheck
+	p2p.SendEnvelopeShim(peer, p2p.Envelope{ // nolint: staticcheck
 		ChannelID: VoteChannel,
 		Message:   &cmtcons.Vote{Vote: precommit.ToProto()},
 	}, cs.Logger)
 }
 
-//----------------------------------------
+// ----------------------------------------
 // byzantine consensus reactor
 
 type ByzantineReactor struct {

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -65,7 +65,7 @@ func ResetConfig(name string) *cfg.Config {
 	return cfg.ResetTestRoot(name)
 }
 
-//-------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------
 // validator stub (a kvstore consensus peer we control)
 
 type validatorStub struct {
@@ -190,7 +190,7 @@ func (vss ValidatorStubsByPower) Swap(i, j int) {
 	vss[j].Index = int32(j)
 }
 
-//-------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------
 // Functions for transitioning the consensus state
 
 func startTestRound(cs *State, height int64, round int32) {
@@ -361,7 +361,7 @@ func subscribeToVoter(cs *State, addr []byte) <-chan cmtpubsub.Message {
 	return ch
 }
 
-//-------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------
 // consensus states
 
 func newState(state sm.State, pv types.PrivValidator, app abci.Application) *State {
@@ -475,7 +475,7 @@ func randState(nValidators int) (*State, []*validatorStub) {
 	return cs, vss
 }
 
-//-------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------
 
 func ensureNoNewEvent(ch <-chan cmtpubsub.Message, timeout time.Duration,
 	errorMessage string,
@@ -697,7 +697,7 @@ func ensureNewEventOnChannel(ch <-chan cmtpubsub.Message) {
 	}
 }
 
-//-------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------
 // consensus nets
 
 // consensusLogger is a TestingLogger which uses a different
@@ -722,10 +722,7 @@ func randConsensusNet(nValidators int, testName string, tickerFunc func() Timeou
 	configRootDirs := make([]string, 0, nValidators)
 	for i := 0; i < nValidators; i++ {
 		stateDB := dbm.NewMemDB() // each state needs its own db
-		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-			DiscardABCIResponses: false,
-		})
-		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+		state, _ := sm.MakeGenesisState(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		configRootDirs = append(configRootDirs, thisConfig.RootDir)
 		for _, opt := range configOpts {
@@ -817,7 +814,7 @@ func getSwitchIndex(switches []*p2p.Switch, peer p2p.Peer) int {
 	panic("didnt find peer in switches")
 }
 
-//-------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------
 // genesis
 
 func randGenesisDoc(numValidators int, randPower bool, minPower int64) (*types.GenesisDoc, []types.PrivValidator) {
@@ -847,7 +844,7 @@ func randGenesisState(numValidators int, randPower bool, minPower int64) (sm.Sta
 	return s0, privValidators
 }
 
-//------------------------------------
+// ------------------------------------
 // mock ticker
 
 func newMockTickerFunc(onlyOnce bool) func() TimeoutTicker {
@@ -895,7 +892,7 @@ func (m *mockTicker) Chan() <-chan timeoutInfo {
 
 func (*mockTicker) SetLogger(log.Logger) {}
 
-//------------------------------------
+// ------------------------------------
 
 func newCounter() abci.Application {
 	return counter.NewApplication(true)

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -56,18 +56,17 @@ func TestMain(m *testing.M) {
 // the `Handshake Tests` are for failures in applying the block.
 // With the help of the WAL, we can recover from it all!
 
-//------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------
 // WAL Tests
 
 // TODO: It would be better to verify explicitly which states we can recover from without the wal
 // and which ones we need the wal for - then we'd also be able to only flush the
 // wal writer when we need to, instead of with every message.
 
-func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *cfg.Config,
-	lastBlockHeight int64, blockDB dbm.DB, stateStore sm.Store,
-) {
+func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *cfg.Config, blockDB dbm.DB) {
 	logger := log.TestingLogger()
-	state, _ := stateStore.LoadFromDBOrGenesisFile(consensusReplayConfig.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(consensusReplayConfig.GenesisFile())
+	require.NoError(t, err)
 	privValidator := loadPrivValidator(consensusReplayConfig)
 	cs := newStateWithConfigAndBlockStore(
 		consensusReplayConfig,
@@ -81,7 +80,7 @@ func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *cfg.Confi
 	bytes, _ := os.ReadFile(cs.config.WalFile())
 	t.Logf("====== WAL: \n\r%X\n", bytes)
 
-	err := cs.Start()
+	err = cs.Start()
 	require.NoError(t, err)
 	defer func() {
 		if err := cs.Stop(); err != nil {
@@ -164,9 +163,6 @@ LOOP:
 		logger := log.NewNopLogger()
 		blockDB := dbm.NewMemDB()
 		stateDB := blockDB
-		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-			DiscardABCIResponses: false,
-		})
 		state, err := sm.MakeGenesisStateFromFile(consensusReplayConfig.GenesisFile())
 		require.NoError(t, err)
 		privValidator := loadPrivValidator(consensusReplayConfig)
@@ -207,7 +203,7 @@ LOOP:
 			t.Logf("WAL panicked: %v", err)
 
 			// make sure we can make blocks after a crash
-			startNewStateAndWaitForBlock(t, consensusReplayConfig, cs.Height, blockDB, stateStore)
+			startNewStateAndWaitForBlock(t, consensusReplayConfig, blockDB)
 
 			// stop consensus state and transactions sender (initFn)
 			cs.Stop() //nolint:errcheck // Logging this error causes failure
@@ -318,7 +314,7 @@ var (
 	sim testSim
 )
 
-//---------------------------------------
+// ---------------------------------------
 // Test handshake/replay
 
 // 0 - all synced up
@@ -1030,7 +1026,7 @@ func (app *badApp) Commit() abci.ResponseCommit {
 	panic("either allHashesAreWrong or onlyLastHashIsWrong must be set")
 }
 
-//--------------------------
+// --------------------------
 // utils for making blocks
 
 func makeBlockchainFromWAL(wal WAL) ([]*types.Block, []*types.Commit, error) {
@@ -1176,7 +1172,7 @@ func stateAndStore(
 	return stateDB, state, store
 }
 
-//----------------------------------
+// ----------------------------------
 // mock block store
 
 type mockBlockStore struct {
@@ -1231,7 +1227,7 @@ func (bs *mockBlockStore) PruneBlocks(height int64) (uint64, error) {
 	return pruned, nil
 }
 
-//---------------------------------------
+// ---------------------------------------
 // Test handshake/init chain
 
 func TestHandshakeUpdatesValidators(t *testing.T) {

--- a/crypto/tmhash/hash.go
+++ b/crypto/tmhash/hash.go
@@ -2,7 +2,10 @@ package tmhash
 
 import (
 	"crypto/sha256"
+	"errors"
+	"fmt"
 	"hash"
+	"regexp"
 )
 
 const (
@@ -21,7 +24,7 @@ func Sum(bz []byte) []byte {
 	return h[:]
 }
 
-//-------------------------------------------------------------
+// -------------------------------------------------------------
 
 const (
 	TruncatedSize = 20
@@ -62,4 +65,28 @@ func NewTruncated() hash.Hash {
 func SumTruncated(bz []byte) []byte {
 	hash := sha256.Sum256(bz)
 	return hash[:TruncatedSize]
+}
+
+// ValidateSHA256 checks if the given string is a syntactically valid SHA256 hash.
+// A valid SHA256 hash is a hex-encoded 64-character string.
+// If the hash isn't valid, it returns an error explaining why.
+func ValidateSHA256(hashStr string) error {
+	const sha256Pattern = `^[a-fA-F0-9]{64}$`
+
+	if len(hashStr) != 64 {
+		return fmt.Errorf("expected 64 characters, but have %d", len(hashStr))
+	}
+
+	match, err := regexp.MatchString(sha256Pattern, hashStr)
+	if err != nil {
+		// if this happens, there is a bug in the regex or some internal regexp
+		// package error.
+		return fmt.Errorf("can't run regex %q: %s", sha256Pattern, err)
+	}
+
+	if !match {
+		return errors.New("contains non-hexadecimal characters")
+	}
+
+	return nil
 }

--- a/node/errors.go
+++ b/node/errors.go
@@ -1,0 +1,60 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNonEmptyBlockStore is returned when the blockstore is not empty and the node is trying to initialize non empty state.
+	ErrNonEmptyBlockStore = errors.New("blockstore not empty, trying to initialize non empty state")
+	// ErrNonEmptyState is returned when the state is not empty and the node is trying to initialize non empty state.
+	ErrNonEmptyState = errors.New("state not empty, trying to initialize non empty state")
+	// ErrSwitchStateSync is returned when the blocksync reactor does not support switching from state sync.
+	ErrSwitchStateSync = errors.New("this blocksync reactor does not support switching from state sync")
+	// ErrGenesisHashDecode is returned when the genesis hash provided by the operator cannot be decoded.
+	ErrGenesisHashDecode = errors.New("genesis hash provided by operator cannot be decoded")
+	// ErrPassedGenesisHashMismatch is returned when the genesis doc hash in the database does not match the passed --genesis_hash value.
+	ErrPassedGenesisHashMismatch = errors.New("genesis doc hash in db does not match passed --genesis_hash value")
+	// ErrLoadedGenesisDocHashMismatch is returned when the genesis doc hash in the database does not match the loaded genesis doc.
+	ErrLoadedGenesisDocHashMismatch = errors.New("genesis doc hash in db does not match loaded genesis doc")
+)
+
+// ErrGenesisDoc is returned when the node fails to load the genesis doc.
+type ErrGenesisDoc struct {
+	Err error
+}
+
+func (e ErrGenesisDoc) Error() string {
+	return fmt.Sprintf("error in genesis doc: %v", e.Err)
+}
+
+func (e ErrGenesisDoc) Unwrap() error {
+	return e.Err
+}
+
+// ErrRetrieveGenesisDocHash is returned when the node fails to retrieve the genesis doc hash from the database.
+type ErrRetrieveGenesisDocHash struct {
+	Err error
+}
+
+func (e ErrRetrieveGenesisDocHash) Error() string {
+	return fmt.Sprintf("error retrieving genesis doc hash: %v", e.Err)
+}
+
+func (e ErrRetrieveGenesisDocHash) Unwrap() error {
+	return e.Err
+}
+
+// ErrSaveGenesisDocHash is returned when the node fails to save the genesis doc hash to the database.
+type ErrSaveGenesisDocHash struct {
+	Err error
+}
+
+func (e ErrSaveGenesisDocHash) Error() string {
+	return fmt.Sprintf("failed to save genesis doc hash to db: %v", e.Err)
+}
+
+func (e ErrSaveGenesisDocHash) Unwrap() error {
+	return e.Err
+}

--- a/node/node.go
+++ b/node/node.go
@@ -3,10 +3,13 @@ package node
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	_ "net/http/pprof" // nolint: gosec // securely exposed on separate, optional port
+	"os"
 	"strings"
 	"time"
 
@@ -22,8 +25,8 @@ import (
 	cfg "github.com/tendermint/tendermint/config"
 	cs "github.com/tendermint/tendermint/consensus"
 	"github.com/tendermint/tendermint/crypto"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/evidence"
-
 	cmtjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	cmtpubsub "github.com/tendermint/tendermint/libs/pubsub"
@@ -53,12 +56,10 @@ import (
 	cmttime "github.com/tendermint/tendermint/types/time"
 	"github.com/tendermint/tendermint/version"
 
-	_ "net/http/pprof" //nolint: gosec // securely exposed on separate, optional port
-
 	_ "github.com/lib/pq" // provide the psql db driver
 )
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 // DBContext specifies config information for loading a new DB.
 type DBContext struct {
@@ -78,16 +79,36 @@ func DefaultDBProvider(ctx *DBContext) (dbm.DB, error) {
 	return dbm.NewDB(ctx.ID, dbType, ctx.Config.DBDir())
 }
 
-// GenesisDocProvider returns a GenesisDoc.
+// ChecksummedGenesisDoc combines a GenesisDoc together with its
+// SHA256 checksum.
+type ChecksummedGenesisDoc struct {
+	GenesisDoc     *types.GenesisDoc
+	Sha256Checksum []byte
+}
+
+// GenesisDocProvider returns a GenesisDoc together with its SHA256 checksum.
 // It allows the GenesisDoc to be pulled from sources other than the
 // filesystem, for instance from a distributed key-value store cluster.
-type GenesisDocProvider func() (*types.GenesisDoc, error)
+type GenesisDocProvider func() (ChecksummedGenesisDoc, error)
 
 // DefaultGenesisDocProviderFunc returns a GenesisDocProvider that loads
 // the GenesisDoc from the config.GenesisFile() on the filesystem.
 func DefaultGenesisDocProviderFunc(config *cfg.Config) GenesisDocProvider {
-	return func() (*types.GenesisDoc, error) {
-		return types.GenesisDocFromFile(config.GenesisFile())
+	return func() (ChecksummedGenesisDoc, error) {
+		// FIXME: find a way to stream the file incrementally,
+		// for the JSON	parser and the checksum computation.
+		// https://github.com/cometbft/cometbft/issues/1302
+		jsonBlob, err := os.ReadFile(config.GenesisFile())
+		if err != nil {
+			return ChecksummedGenesisDoc{}, fmt.Errorf("couldn't read GenesisDoc file: %w", err)
+
+		}
+		incomingChecksum := tmhash.Sum(jsonBlob)
+		genDoc, err := types.GenesisDocFromJSON(jsonBlob)
+		if err != nil {
+			return ChecksummedGenesisDoc{}, err
+		}
+		return ChecksummedGenesisDoc{GenesisDoc: genDoc, Sha256Checksum: incomingChecksum}, nil
 	}
 }
 
@@ -189,7 +210,7 @@ func StateProvider(stateProvider statesync.StateProvider) Option {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 // Node is the highest level interface to a full CometBFT node.
 // It includes all configuration information and running services.
@@ -720,11 +741,7 @@ func NewNode(config *cfg.Config,
 		return nil, err
 	}
 
-	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
-	})
-
-	state, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider)
+	state, stateStore, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1304,7 +1321,7 @@ func (n *Node) Config() *cfg.Config {
 	return n.config
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 func (n *Node) Listeners() []string {
 	return []string{
@@ -1384,38 +1401,86 @@ func makeNodeInfo(
 	return nodeInfo, err
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
+var genesisDocHashKey = []byte("genesisDocHash")
 var genesisDocKey = []byte("genesisDoc")
+
+// LoadStateFromDBOrGenesisDocProviderWithConfig attempts to load the state from the
+// database, or creates one using the given genesisDocProvider. On success this also
+// returns the genesis doc loaded through the given provider.
+func LoadStateFromDBOrGenesisDocProviderWithConfig(
+	stateDB dbm.DB,
+	genesisDocProvider GenesisDocProvider,
+	operatorGenesisHashHex string,
+	config *cfg.Config,
+) (sm.State, sm.Store, *types.GenesisDoc, error) {
+	// 1. Verify genesisDoc hash in db if exists
+	genDocHash, err := stateDB.Get(genesisDocHashKey)
+	if err != nil {
+		return sm.State{}, nil, nil, ErrRetrieveGenesisDocHash{Err: err}
+	}
+
+	csGenDoc, err := genesisDocProvider()
+	if err != nil {
+		return sm.State{}, nil, nil, err
+	}
+
+	if err = csGenDoc.GenesisDoc.ValidateAndComplete(); err != nil {
+		return sm.State{}, nil, nil, ErrGenesisDoc{Err: err}
+	}
+
+	checkSumStr := hex.EncodeToString(csGenDoc.Sha256Checksum)
+	if err := tmhash.ValidateSHA256(checkSumStr); err != nil {
+		const formatStr = "invalid genesis doc SHA256 checksum: %s"
+		return sm.State{}, nil, nil, fmt.Errorf(formatStr, err)
+	}
+
+	// Validate that existing or recently saved genesis file hash matches optional --genesis_hash passed by operator
+	if operatorGenesisHashHex != "" {
+		decodedOperatorGenesisHash, err := hex.DecodeString(operatorGenesisHashHex)
+		if err != nil {
+			return sm.State{}, nil, nil, ErrGenesisHashDecode
+		}
+		if !bytes.Equal(csGenDoc.Sha256Checksum, decodedOperatorGenesisHash) {
+			return sm.State{}, nil, nil, ErrPassedGenesisHashMismatch
+		}
+	}
+
+	if len(genDocHash) == 0 {
+		// Save the genDoc hash in the store if it doesn't already exist for future verification
+		if err = stateDB.SetSync(genesisDocHashKey, csGenDoc.Sha256Checksum); err != nil {
+			return sm.State{}, nil, nil, ErrSaveGenesisDocHash{Err: err}
+		}
+	} else {
+		if !bytes.Equal(genDocHash, csGenDoc.Sha256Checksum) {
+			return sm.State{}, nil, nil, ErrLoadedGenesisDocHashMismatch
+		}
+	}
+
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+
+	state, err := stateStore.LoadFromDBOrGenesisDoc(csGenDoc.GenesisDoc)
+	if err != nil {
+		return sm.State{}, nil, nil, err
+	}
+
+	return state, stateStore, csGenDoc.GenesisDoc, nil
+}
 
 // LoadStateFromDBOrGenesisDocProvider attempts to load the state from the
 // database, or creates one using the given genesisDocProvider. On success this also
 // returns the genesis doc loaded through the given provider.
+// Note that if you don't have a version of the key layout set in your DB already,
+// and no config is passed, it will default to v1.
 func LoadStateFromDBOrGenesisDocProvider(
 	stateDB dbm.DB,
 	genesisDocProvider GenesisDocProvider,
-) (sm.State, *types.GenesisDoc, error) {
-	// Get genesis doc
-	genDoc, err := loadGenesisDoc(stateDB)
-	if err != nil {
-		genDoc, err = genesisDocProvider()
-		if err != nil {
-			return sm.State{}, nil, err
-		}
-		// save genesis doc to prevent a certain class of user errors (e.g. when it
-		// was changed, accidentally or not). Also good for audit trail.
-		if err := saveGenesisDoc(stateDB, genDoc); err != nil {
-			return sm.State{}, nil, err
-		}
-	}
-	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
-	state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
-	if err != nil {
-		return sm.State{}, nil, err
-	}
-	return state, genDoc, nil
+	operatorGenesisHashHex string,
+) (sm.State, sm.Store, *types.GenesisDoc, error) {
+	return LoadStateFromDBOrGenesisDocProviderWithConfig(stateDB, genesisDocProvider, operatorGenesisHashHex, nil)
 }
 
 // panics if failed to unmarshal bytes

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -17,8 +17,11 @@ import (
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	cfg "github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto/ed25519"
+	"github.com/tendermint/tendermint/crypto/tmhash"
 	"github.com/tendermint/tendermint/evidence"
+	cmtjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
+	cmtos "github.com/tendermint/tendermint/libs/os"
 	cmtrand "github.com/tendermint/tendermint/libs/rand"
 	mempl "github.com/tendermint/tendermint/mempool"
 	mempoolv0 "github.com/tendermint/tendermint/mempool/v0"
@@ -445,6 +448,54 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 	channels := n.NodeInfo().(p2p.DefaultNodeInfo).Channels
 	assert.Contains(t, channels, mempl.MempoolChannel)
 	assert.Contains(t, channels, cr.Channels[0].ID)
+}
+
+func TestNodeNewNodeGenesisHashMismatch(t *testing.T) {
+	config := cfg.ResetTestRoot("node_new_node_genesis_hash")
+	defer os.RemoveAll(config.RootDir)
+
+	// Use goleveldb so we can reuse the same db for the second NewNode()
+	config.DBBackend = string(dbm.GoLevelDBBackend)
+
+	// nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
+	// require.NoError(t, err)
+
+	n, err := DefaultNewNode(config, log.TestingLogger())
+	require.NoError(t, err)
+
+	// Start and stop to close the db for later reading
+	err = n.Start()
+	require.NoError(t, err)
+
+	err = n.Stop()
+	require.NoError(t, err)
+
+	// Ensure the genesis doc hash is saved to db
+	// stateDB, err := cfg.DefaultDBProvider(&cfg.DBContext{ID: "state", Config: config})
+	stateDB := dbm.NewMemDB()
+	// require.NoError(t, err)
+
+	genDocHash, err := stateDB.Get(genesisDocHashKey)
+	require.NoError(t, err)
+	require.NotNil(t, genDocHash, "genesis doc hash should be saved in db")
+	require.Len(t, genDocHash, tmhash.Size)
+
+	err = stateDB.Close()
+	require.NoError(t, err)
+
+	// Modify the genesis file chain ID to get a different hash
+	genBytes := cmtos.MustReadFile(config.GenesisFile())
+	var genesisDoc types.GenesisDoc
+	err = cmtjson.Unmarshal(genBytes, &genesisDoc)
+	require.NoError(t, err)
+
+	genesisDoc.ChainID = "different-chain-id"
+	err = genesisDoc.SaveAs(config.GenesisFile())
+	require.NoError(t, err)
+
+	_, err = DefaultNewNode(config, log.TestingLogger())
+	require.Error(t, err, "NewNode should error when genesisDoc is changed")
+	require.Equal(t, "genesis doc hash in db does not match loaded genesis doc", err.Error())
 }
 
 func state(nVals int, height int64) (sm.State, dbm.DB, []types.PrivValidator) {


### PR DESCRIPTION
This avoids saving the genesisDoc to database.
When using goleveldb and ~4GiB+ genesis files, it causes a panic during snappy encoding (panic: snappy: decoded block is too large).

refs akash-network/support#280

backports:
- https://github.com/cometbft/cometbft/pull/1017
- https://github.com/cometbft/cometbft/pull/1293
