### PR TITLE
feat: port remove genesis persistence from state

### DIFF
--- a/blocksync/reactor_test.go
+++ b/blocksync/reactor_test.go
@@ -85,13 +85,9 @@ func newReactor(
 	}
 
 	blockDB := dbm.NewMemDB()
-	stateDB := dbm.NewMemDB()
-	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
 	blockStore := store.NewBlockStore(blockDB)
 
-	state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+	state, err := sm.MakeGenesisState(genDoc)
 	if err != nil {
 		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
 	}
@@ -113,7 +109,7 @@ func newReactor(
 	// pool.height is determined from the store.
 	blockSync := true
 	db := dbm.NewMemDB()
-	stateStore = sm.NewStore(db, sm.StoreOptions{
+	stateStore := sm.NewStore(db, sm.StoreOptions{
 		DiscardABCIResponses: false,
 	})
 	blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyApp.Consensus(),

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -55,13 +55,15 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 			DiscardABCIResponses: false,
 		})
-		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+		state, err := sm.MakeGenesisState(genDoc)
+		require.NoError(t, err)
+		require.NoError(t, stateStore.Save(state))
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		defer os.RemoveAll(thisConfig.RootDir)
 		ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0o700) // dir for wal
 		app := appFunc()
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
-		_, err := app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
+		_, err = app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
 		require.NoError(t, err)
 
 		blockDB := dbm.NewMemDB()

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -773,10 +773,7 @@ func randConsensusNet(t *testing.T, nValidators int, testName string, tickerFunc
 	configRootDirs := make([]string, 0, nValidators)
 	for i := 0; i < nValidators; i++ {
 		stateDB := dbm.NewMemDB() // each state needs its own db
-		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-			DiscardABCIResponses: false,
-		})
-		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+		state, _ := sm.MakeGenesisState(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		configRootDirs = append(configRootDirs, thisConfig.RootDir)
 		for _, opt := range configOpts {
@@ -820,7 +817,7 @@ func randConsensusNetWithPeers(
 			DiscardABCIResponses: false,
 		})
 		t.Cleanup(func() { _ = stateStore.Close() })
-		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+		state, _ := sm.MakeGenesisState(genDoc)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		configRootDirs = append(configRootDirs, thisConfig.RootDir)
 		ensureDir(filepath.Dir(thisConfig.Consensus.WalFile()), 0o700) // dir for wal

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -140,13 +140,14 @@ func TestReactorWithEvidence(t *testing.T) {
 		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 			DiscardABCIResponses: false,
 		})
-		state, _ := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+		state, err := sm.MakeGenesisState(genDoc)
+		require.NoError(t, err)
 		thisConfig := ResetConfig(fmt.Sprintf("%s_%d", testName, i))
 		defer os.RemoveAll(thisConfig.RootDir)
 		ensureDir(path.Dir(thisConfig.Consensus.WalFile()), 0o700) // dir for wal
 		app := appFunc()
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
-		_, err := app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
+		_, err = app.InitChain(context.Background(), &abci.RequestInitChain{Validators: vals})
 		require.NoError(t, err)
 
 		pv := privVals[i]

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -73,7 +73,8 @@ func startNewStateAndWaitForBlock(
 	stateStore sm.Store,
 ) {
 	logger := log.TestingLogger()
-	state, _ := stateStore.LoadFromDBOrGenesisFile(consensusReplayConfig.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(consensusReplayConfig.GenesisFile())
+	require.NoError(t, err)
 	privValidator := loadPrivValidator(consensusReplayConfig)
 	cs := newStateWithConfigAndBlockStore(
 		consensusReplayConfig,
@@ -87,7 +88,7 @@ func startNewStateAndWaitForBlock(
 	bytes, _ := os.ReadFile(cs.config.WalFile())
 	t.Logf("====== WAL: \n\r%X\n", bytes)
 
-	err := cs.Start()
+	err = cs.Start()
 	require.NoError(t, err)
 	defer func() {
 		if err := cs.Stop(); err != nil {

--- a/crypto/tmhash/hash.go
+++ b/crypto/tmhash/hash.go
@@ -2,7 +2,10 @@ package tmhash
 
 import (
 	"crypto/sha256"
+	"errors"
+	"fmt"
 	"hash"
+	"regexp"
 )
 
 const (
@@ -31,6 +34,30 @@ func SumMany(data []byte, rest ...[]byte) []byte {
 		h.Write(data)
 	}
 	return h.Sum(nil)
+}
+
+// ValidateSHA256 checks if the given string is a syntactically valid SHA256 hash.
+// A valid SHA256 hash is a hex-encoded 64-character string.
+// If the hash isn't valid, it returns an error explaining why.
+func ValidateSHA256(hashStr string) error {
+	const sha256Pattern = `^[a-fA-F0-9]{64}$`
+
+	if len(hashStr) != 64 {
+		return fmt.Errorf("expected 64 characters, but have %d", len(hashStr))
+	}
+
+	match, err := regexp.MatchString(sha256Pattern, hashStr)
+	if err != nil {
+		// if this happens, there is a bug in the regex or some internal regexp
+		// package error.
+		return fmt.Errorf("can't run regex %q: %s", sha256Pattern, err)
+	}
+
+	if !match {
+		return errors.New("contains non-hexadecimal characters")
+	}
+
+	return nil
 }
 
 //-------------------------------------------------------------

--- a/node/errors.go
+++ b/node/errors.go
@@ -1,0 +1,291 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrNonEmptyBlockStore is returned when the blockstore is not empty and the node is trying to initialize non empty state.
+	ErrNonEmptyBlockStore = errors.New("blockstore not empty, trying to initialize non empty state")
+	// ErrNonEmptyState is returned when the state is not empty and the node is trying to initialize non empty state.
+	ErrNonEmptyState = errors.New("state not empty, trying to initialize non empty state")
+	// ErrSwitchStateSync is returned when the blocksync reactor does not support switching from state sync.
+	ErrSwitchStateSync = errors.New("this blocksync reactor does not support switching from state sync")
+	// ErrGenesisHashDecode is returned when the genesis hash provided by the operator cannot be decoded.
+	ErrGenesisHashDecode = errors.New("genesis hash provided by operator cannot be decoded")
+	// ErrPassedGenesisHashMismatch is returned when the genesis doc hash in the database does not match the passed --genesis_hash value.
+	ErrPassedGenesisHashMismatch = errors.New("genesis doc hash in db does not match passed --genesis_hash value")
+	// ErrLoadedGenesisDocHashMismatch is returned when the genesis doc hash in the database does not match the loaded genesis doc.
+	ErrLoadedGenesisDocHashMismatch = errors.New("genesis doc hash in db does not match loaded genesis doc")
+)
+
+// ErrLightClientStateProvider is returned when the node fails to create the blockstore.
+type ErrLightClientStateProvider struct {
+	Err error
+}
+
+func (e ErrLightClientStateProvider) Error() string {
+	return fmt.Sprintf("failed to set up light client state provider: %v", e.Err)
+}
+
+func (e ErrLightClientStateProvider) Unwrap() error {
+	return e.Err
+}
+
+// ErrMismatchAppHash is returned when the app hash returned by the light client does not match the provided appHash.
+type ErrMismatchAppHash struct {
+	Expected, Actual []byte
+}
+
+func (e ErrMismatchAppHash) Error() string {
+	return fmt.Sprintf("the app hash returned by the light client does not match the provided appHash, expected %X, got %X", e.Expected, e.Actual)
+}
+
+// ErrSetSyncHeight is returned when the node fails to set the synced height.
+type ErrSetSyncHeight struct {
+	Err error
+}
+
+func (e ErrSetSyncHeight) Error() string {
+	return fmt.Sprintf("failed to set synced height: %v", e.Err)
+}
+
+// ErrPrivValidatorSocketClient is returned when the node fails to create private validator socket client.
+type ErrPrivValidatorSocketClient struct {
+	Err error
+}
+
+func (e ErrPrivValidatorSocketClient) Error() string {
+	return fmt.Sprintf("error with private validator socket client: %v", e.Err)
+}
+
+func (e ErrPrivValidatorSocketClient) Unwrap() error {
+	return e.Err
+}
+
+// ErrGetPubKey is returned when the node fails to get the public key.
+type ErrGetPubKey struct {
+	Err error
+}
+
+func (e ErrGetPubKey) Error() string {
+	return fmt.Sprintf("can't get pubkey: %v", e.Err)
+}
+
+func (e ErrGetPubKey) Unwrap() error {
+	return e.Err
+}
+
+// ErrCreatePruner is returned when the node fails to create the pruner.
+type ErrCreatePruner struct {
+	Err error
+}
+
+func (e ErrCreatePruner) Error() string {
+	return fmt.Sprintf("failed to create pruner: %v", e.Err)
+}
+
+func (e ErrCreatePruner) Unwrap() error {
+	return e.Err
+}
+
+// ErrCreateBlockSyncReactor is returned when the node fails to create the blocksync reactor.
+type ErrCreateBlockSyncReactor struct {
+	Err error
+}
+
+func (e ErrCreateBlockSyncReactor) Error() string {
+	return fmt.Sprintf("could not create blocksync reactor: %v", e.Err)
+}
+
+func (e ErrCreateBlockSyncReactor) Unwrap() error {
+	return e.Err
+}
+
+// ErrAddPersistentPeers is returned when the node fails to add peers from the persistent_peers field.
+type ErrAddPersistentPeers struct {
+	Err error
+}
+
+func (e ErrAddPersistentPeers) Error() string {
+	return fmt.Sprintf("could not add peers from persistent_peers field: %v", e.Err)
+}
+
+func (e ErrAddPersistentPeers) Unwrap() error {
+	return e.Err
+}
+
+// ErrAddUnconditionalPeerIDs is returned when the node fails to add peer ids from the unconditional_peer_ids field.
+type ErrAddUnconditionalPeerIDs struct {
+	Err error
+}
+
+func (e ErrAddUnconditionalPeerIDs) Error() string {
+	return fmt.Sprintf("could not add peer ids from unconditional_peer_ids field: %v", e.Err)
+}
+
+func (e ErrAddUnconditionalPeerIDs) Unwrap() error {
+	return e.Err
+}
+
+// ErrCreateAddrBook is returned when the node fails to create the address book.
+type ErrCreateAddrBook struct {
+	Err error
+}
+
+func (e ErrCreateAddrBook) Error() string {
+	return fmt.Sprintf("could not create addrbook: %v", e.Err)
+}
+
+func (e ErrCreateAddrBook) Unwrap() error {
+	return e.Err
+}
+
+// ErrDialPeers is returned when the node fails to dial peers from the persistent_peers field.
+type ErrDialPeers struct {
+	Err error
+}
+
+func (e ErrDialPeers) Error() string {
+	return fmt.Sprintf("could not dial peers from persistent_peers field: %v", e.Err)
+}
+
+func (e ErrDialPeers) Unwrap() error {
+	return e.Err
+}
+
+// ErrHandshake is returned when CometBFT fails to complete the handshake with the ABCI app.
+type ErrHandshake struct {
+	Err error
+}
+
+func (e ErrHandshake) Error() string {
+	return fmt.Sprintf("could not complete handshake with the app: %v", e.Err)
+}
+
+func (e ErrHandshake) Unwrap() error {
+	return e.Err
+}
+
+// ErrStartStateSync is returned when the node fails to start the statesync.
+type ErrStartStateSync struct {
+	Err error
+}
+
+func (e ErrStartStateSync) Error() string {
+	return fmt.Sprintf("failed to start statesync: %v", e.Err)
+}
+
+func (e ErrStartStateSync) Unwrap() error {
+	return e.Err
+}
+
+// ErrStartPruning is returned when the node fails to start background pruning routine.
+type ErrStartPruning struct {
+	Err error
+}
+
+func (e ErrStartPruning) Error() string {
+	return fmt.Sprintf("failed to start background pruning routine: %v", e.Err)
+}
+
+func (e ErrStartPruning) Unwrap() error {
+	return e.Err
+}
+
+// ErrLoadOrGenNodeKey is returned when the node fails to load or generate the node key.
+type ErrLoadOrGenNodeKey struct {
+	Err         error
+	NodeKeyFile string
+}
+
+func (e ErrLoadOrGenNodeKey) Error() string {
+	return fmt.Sprintf("failed to load or gen node key %s: %v", e.NodeKeyFile, e.Err)
+}
+
+func (e ErrLoadOrGenNodeKey) Unwrap() error {
+	return e.Err
+}
+
+// ErrRetrieveGenesisDocHash is returned when the node fails to retrieve the genesis doc hash from the database.
+type ErrRetrieveGenesisDocHash struct {
+	Err error
+}
+
+func (e ErrRetrieveGenesisDocHash) Error() string {
+	return fmt.Sprintf("error retrieving genesis doc hash: %v", e.Err)
+}
+
+func (e ErrRetrieveGenesisDocHash) Unwrap() error {
+	return e.Err
+}
+
+// ErrGenesisDoc is returned when the node fails to load the genesis doc.
+type ErrGenesisDoc struct {
+	Err error
+}
+
+func (e ErrGenesisDoc) Error() string {
+	return fmt.Sprintf("error in genesis doc: %v", e.Err)
+}
+
+func (e ErrGenesisDoc) Unwrap() error {
+	return e.Err
+}
+
+// ErrSaveGenesisDocHash is returned when the node fails to save the genesis doc hash to the database.
+type ErrSaveGenesisDocHash struct {
+	Err error
+}
+
+func (e ErrSaveGenesisDocHash) Error() string {
+	return fmt.Sprintf("failed to save genesis doc hash to db: %v", e.Err)
+}
+
+func (e ErrSaveGenesisDocHash) Unwrap() error {
+	return e.Err
+}
+
+// ErrorReadingGenesisDoc is returned when the node fails to read the genesis doc file.
+type ErrorReadingGenesisDoc struct {
+	Err error
+}
+
+func (e ErrorReadingGenesisDoc) Error() string {
+	return fmt.Sprintf("could not read GenesisDoc file: %v", e.Err)
+}
+
+func (e ErrorReadingGenesisDoc) Unwrap() error {
+	return e.Err
+}
+
+// ErrorLoadOrGenNodeKey is returned when the node fails to load or generate node key.
+type ErrorLoadOrGenNodeKey struct {
+	Err         error
+	NodeKeyFile string
+}
+
+func (e ErrorLoadOrGenNodeKey) Error() string {
+	return fmt.Sprintf("failed to load or generate node key %s: %v", e.NodeKeyFile, e.Err)
+}
+
+func (e ErrorLoadOrGenNodeKey) Unwrap() error {
+	return e.Err
+}
+
+// ErrorLoadOrGenFilePV is returned when the node fails to load or generate priv validator file.
+type ErrorLoadOrGenFilePV struct {
+	Err       error
+	KeyFile   string
+	StateFile string
+}
+
+func (e ErrorLoadOrGenFilePV) Error() string {
+	return fmt.Sprintf("failed to load or generate privval file; "+
+		"key file %s, state file %s: %v", e.KeyFile, e.StateFile, e.Err)
+}
+
+func (e ErrorLoadOrGenFilePV) Unwrap() error {
+	return e.Err
+}

--- a/node/node.go
+++ b/node/node.go
@@ -3,9 +3,11 @@ package node
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
+	_ "net/http/pprof" //nolint: gosec
 	"os"
 	"time"
 
@@ -38,8 +40,6 @@ import (
 	"github.com/cometbft/cometbft/types"
 	cmttime "github.com/cometbft/cometbft/types/time"
 	"github.com/cometbft/cometbft/version"
-
-	_ "net/http/pprof" //nolint: gosec
 )
 
 // Node is the highest level interface to a full CometBFT node.
@@ -84,8 +84,14 @@ type Node struct {
 	pprofSrv          *http.Server
 }
 
+type Options struct {
+	stateSyncProvider statesync.StateProvider
+	reactors          map[string]p2p.Reactor
+	genesisHash       []byte
+}
+
 // Option sets a parameter for the node.
-type Option func(*Node)
+type Option func(*Options)
 
 // CustomReactors allows you to add custom reactors (name -> p2p.Reactor) to
 // the node's Switch.
@@ -100,30 +106,8 @@ type Option func(*Node)
 //   - PEX
 //   - STATESYNC
 func CustomReactors(reactors map[string]p2p.Reactor) Option {
-	return func(n *Node) {
-		for name, reactor := range reactors {
-			if existingReactor := n.sw.Reactor(name); existingReactor != nil {
-				n.sw.Logger.Info("Replacing existing reactor with a custom one",
-					"name", name, "existing", existingReactor, "custom", reactor)
-				n.sw.RemoveReactor(name, existingReactor)
-			}
-			n.sw.AddReactor(name, reactor)
-			// register the new channels to the nodeInfo
-			// NOTE: This is a bit messy now with the type casting but is
-			// cleaned up in the following version when NodeInfo is changed from
-			// and interface to a concrete type
-			if ni, ok := n.nodeInfo.(p2p.DefaultNodeInfo); ok {
-				for _, chDesc := range reactor.GetChannels() {
-					if !ni.HasChannel(chDesc.ID) {
-						ni.Channels = append(ni.Channels, chDesc.ID)
-						n.transport.AddChannel(chDesc.ID)
-					}
-				}
-				n.nodeInfo = ni
-			} else {
-				n.Logger.Error("Node info is not of type DefaultNodeInfo. Custom reactor channels can not be added.")
-			}
-		}
+	return func(n *Options) {
+		n.reactors = reactors
 	}
 }
 
@@ -131,8 +115,18 @@ func CustomReactors(reactors map[string]p2p.Reactor) Option {
 // build a State object for bootstrapping the node.
 // WARNING: this interface is considered unstable and subject to change.
 func StateProvider(stateProvider statesync.StateProvider) Option {
-	return func(n *Node) {
+	return func(n *Options) {
 		n.stateSyncProvider = stateProvider
+	}
+}
+
+// GenesisHash is used is compared against the computed hash of the
+// actual genesis file or the hash stored in the database.
+// If there is a mismatch between the hash provided via cli and the
+// hash of the genesis file or the hash in the DB, the node will not boot.
+func GenesisHash(val []byte) Option {
+	return func(n *Options) {
+		n.genesisHash = val
 	}
 }
 
@@ -202,7 +196,7 @@ func BootstrapStateWithGenProvider(ctx context.Context, config *cfg.Config, dbPr
 		return fmt.Errorf("state not empty, trying to initialize non empty state")
 	}
 
-	genState, _, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genProvider)
+	genState, _, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genProvider, "")
 	if err != nil {
 		return err
 	}
@@ -266,7 +260,9 @@ func BootstrapStateWithGenProvider(ctx context.Context, config *cfg.Config, dbPr
 //------------------------------------------------------------------------------
 
 // NewNode returns a new, ready to go, CometBFT Node.
-func NewNode(config *cfg.Config,
+func NewNode(
+	ctx context.Context,
+	config *cfg.Config,
 	privValidator types.PrivValidator,
 	nodeKey *p2p.NodeKey,
 	clientCreator proxy.ClientCreator,
@@ -276,9 +272,17 @@ func NewNode(config *cfg.Config,
 	logger log.Logger,
 	options ...Option,
 ) (*Node, error) {
-	return NewNodeWithContext(context.TODO(), config, privValidator,
-		nodeKey, clientCreator, genesisDocProvider, dbProvider,
-		metricsProvider, logger, options...)
+	return NewNodeWithContext(
+		ctx,
+		config,
+		privValidator,
+		nodeKey,
+		clientCreator,
+		genesisDocProvider,
+		dbProvider,
+		metricsProvider,
+		logger,
+		options...)
 }
 
 // NewNodeWithContext is cancellable version of NewNode.
@@ -293,21 +297,30 @@ func NewNodeWithContext(ctx context.Context,
 	logger log.Logger,
 	options ...Option,
 ) (*Node, error) {
+	opts := &Options{}
+	for _, opt := range options {
+		opt(opts)
+	}
+
 	blockStore, stateDB, err := initDBs(config, dbProvider)
 	if err != nil {
 		return nil, err
 	}
 
-	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
-	})
-
-	state, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider)
+	var genesisHash string
+	if len(opts.genesisHash) != 0 {
+		genesisHash = hex.EncodeToString(opts.genesisHash)
+	}
+	state, genDoc, err := LoadStateFromDBOrGenesisDocProvider(stateDB, genesisDocProvider, genesisHash)
 	if err != nil {
 		return nil, err
 	}
 
 	csMetrics, p2pMetrics, memplMetrics, smMetrics, abciMetrics, bsMetrics, ssMetrics := metricsProvider(genDoc.ChainID)
+
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+		DiscardABCIResponses: config.Storage.DiscardABCIResponses,
+	})
 
 	// Create the proxyApp and establish connections to the ABCI app (consensus, mempool, query).
 	proxyApp, err := createAndStartProxyAppConns(clientCreator, logger, abciMetrics)
@@ -487,28 +500,49 @@ func NewNodeWithContext(ctx context.Context,
 		nodeInfo:  nodeInfo,
 		nodeKey:   nodeKey,
 
-		stateStore:       stateStore,
-		blockStore:       blockStore,
-		bcReactor:        bcReactor,
-		mempoolReactor:   mempoolReactor,
-		mempool:          mempool,
-		consensusState:   consensusState,
-		consensusReactor: consensusReactor,
-		stateSyncReactor: stateSyncReactor,
-		stateSync:        stateSync,
-		stateSyncGenesis: state, // Shouldn't be necessary, but need a way to pass the genesis state
-		pexReactor:       pexReactor,
-		evidencePool:     evidencePool,
-		proxyApp:         proxyApp,
-		txIndexer:        txIndexer,
-		indexerService:   indexerService,
-		blockIndexer:     blockIndexer,
-		eventBus:         eventBus,
+		stateStore:        stateStore,
+		blockStore:        blockStore,
+		bcReactor:         bcReactor,
+		mempoolReactor:    mempoolReactor,
+		mempool:           mempool,
+		consensusState:    consensusState,
+		consensusReactor:  consensusReactor,
+		stateSyncProvider: opts.stateSyncProvider,
+		stateSyncReactor:  stateSyncReactor,
+		stateSync:         stateSync,
+		stateSyncGenesis:  state, // Shouldn't be necessary, but need a way to pass the genesis state
+		pexReactor:        pexReactor,
+		evidencePool:      evidencePool,
+		proxyApp:          proxyApp,
+		txIndexer:         txIndexer,
+		indexerService:    indexerService,
+		blockIndexer:      blockIndexer,
+		eventBus:          eventBus,
 	}
 	node.BaseService = *service.NewBaseService(logger, "Node", node)
 
-	for _, option := range options {
-		option(node)
+	for name, reactor := range opts.reactors {
+		if existingReactor := node.sw.Reactor(name); existingReactor != nil {
+			node.sw.Logger.Info("Replacing existing reactor with a custom one",
+				"name", name, "existing", existingReactor, "custom", reactor)
+			node.sw.RemoveReactor(name, existingReactor)
+		}
+		node.sw.AddReactor(name, reactor)
+		// register the new channels to the nodeInfo
+		// NOTE: This is a bit messy now with the type casting but is
+		// cleaned up in the following version when NodeInfo is changed from
+		// and interface to a concrete type
+		if ni, ok := node.nodeInfo.(p2p.DefaultNodeInfo); ok {
+			for _, chDesc := range reactor.GetChannels() {
+				if !ni.HasChannel(chDesc.ID) {
+					ni.Channels = append(ni.Channels, chDesc.ID)
+					node.transport.AddChannel(chDesc.ID)
+				}
+			}
+			node.nodeInfo = ni
+		} else {
+			node.Logger.Error("Node info is not of type DefaultNodeInfo. Custom reactor channels can not be added.")
+		}
 	}
 
 	return node, nil

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -437,7 +437,9 @@ func TestNodeNewNodeCustomReactors(t *testing.T) {
 	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
 	require.NoError(t, err)
 
-	n, err := NewNode(config,
+	n, err := NewNode(
+		context.Background(),
+		config,
 		privval.LoadOrGenFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile()),
 		nodeKey,
 		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),

--- a/node/setup.go
+++ b/node/setup.go
@@ -3,13 +3,14 @@ package node
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
+	_ "net/http/pprof" //nolint: gosec // securely exposed on separate, optional port
+	"os"
 	"strings"
 	"time"
-
-	_ "net/http/pprof" //nolint: gosec // securely exposed on separate, optional port
 
 	dbm "github.com/cometbft/cometbft-db"
 
@@ -18,6 +19,7 @@ import (
 	cfg "github.com/cometbft/cometbft/config"
 	cs "github.com/cometbft/cometbft/consensus"
 	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/evidence"
 	"github.com/cometbft/cometbft/statesync"
 
@@ -42,16 +44,48 @@ import (
 
 const readHeaderTimeout = 10 * time.Second
 
-// GenesisDocProvider returns a GenesisDoc.
+// ChecksummedGenesisDoc combines a GenesisDoc together with its
+// SHA256 checksum.
+type ChecksummedGenesisDoc struct {
+	GenesisDoc     *types.GenesisDoc
+	Sha256Checksum []byte
+}
+
+// StartParams Introduced to store parameters passed via cli and needed to start the node.
+// These parameters should not be stored or persisted in the config file.
+// This can then be further extended to include additional flags without further
+// API breaking changes.
+type StartParams struct {
+	// SHA-256 hash of the genesis file provided via the command line.
+	// This hash is used is compared against the computed hash of the
+	// actual genesis file or the hash stored in the database.
+	// If there is a mismatch between the hash provided via cli and the
+	// hash of the genesis file or the hash in the DB, the node will not boot.
+	GenesisHash []byte
+}
+
+// GenesisDocProvider returns a GenesisDoc together with its SHA256 checksum.
 // It allows the GenesisDoc to be pulled from sources other than the
-// filesystem, for instance from a distributed key-value store cluster.
-type GenesisDocProvider func() (*types.GenesisDoc, error)
+// filesystem, for instance, from a distributed key-value store cluster.
+type GenesisDocProvider func() (ChecksummedGenesisDoc, error)
 
 // DefaultGenesisDocProviderFunc returns a GenesisDocProvider that loads
 // the GenesisDoc from the config.GenesisFile() on the filesystem.
 func DefaultGenesisDocProviderFunc(config *cfg.Config) GenesisDocProvider {
-	return func() (*types.GenesisDoc, error) {
-		return types.GenesisDocFromFile(config.GenesisFile())
+	return func() (ChecksummedGenesisDoc, error) {
+		// FIXME: find a way to stream the file incrementally,
+		// for the JSON	parser and the checksum computation.
+		// https://github.com/cometbft/cometbft/issues/1302
+		jsonBlob, err := os.ReadFile(config.GenesisFile())
+		if err != nil {
+			return ChecksummedGenesisDoc{}, fmt.Errorf("couldn't read GenesisDoc file: %w", err)
+		}
+		incomingChecksum := tmhash.Sum(jsonBlob)
+		genDoc, err := types.GenesisDocFromJSON(jsonBlob)
+		if err != nil {
+			return ChecksummedGenesisDoc{}, err
+		}
+		return ChecksummedGenesisDoc{GenesisDoc: genDoc, Sha256Checksum: incomingChecksum}, nil
 	}
 }
 
@@ -67,7 +101,9 @@ func DefaultNewNode(config *cfg.Config, logger log.Logger) (*Node, error) {
 		return nil, fmt.Errorf("failed to load or gen node key %s: %w", config.NodeKeyFile(), err)
 	}
 
-	return NewNode(config,
+	return NewNode(
+		context.Background(),
+		config,
 		privval.LoadOrGenFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile()),
 		nodeKey,
 		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
@@ -549,40 +585,80 @@ func startStateSync(
 //------------------------------------------------------------------------------
 
 var genesisDocKey = []byte("genesisDoc")
+var genesisDocHashKey = []byte("genesisDocHash")
+
+func LoadStateFromDBOrGenesisDocProviderWithConfig(
+	stateDB dbm.DB,
+	genesisDocProvider GenesisDocProvider,
+	operatorGenesisHashHex string,
+	config *cfg.Config,
+) (sm.State, *types.GenesisDoc, error) {
+	// 1. Verify genesisDoc hash in db if exists
+	genDocHash, err := stateDB.Get(genesisDocHashKey)
+	if err != nil {
+		return sm.State{}, nil, ErrRetrieveGenesisDocHash{Err: err}
+	}
+
+	csGenDoc, err := genesisDocProvider()
+	if err != nil {
+		return sm.State{}, nil, err
+	}
+
+	if err = csGenDoc.GenesisDoc.ValidateAndComplete(); err != nil {
+		return sm.State{}, nil, ErrGenesisDoc{Err: err}
+	}
+
+	checkSumStr := hex.EncodeToString(csGenDoc.Sha256Checksum)
+	if err := tmhash.ValidateSHA256(checkSumStr); err != nil {
+		const formatStr = "invalid genesis doc SHA256 checksum: %s"
+		return sm.State{}, nil, fmt.Errorf(formatStr, err)
+	}
+
+	// Validate that existing or recently saved genesis file hash matches optional --genesis_hash passed by operator
+	if operatorGenesisHashHex != "" {
+		decodedOperatorGenesisHash, err := hex.DecodeString(operatorGenesisHashHex)
+		if err != nil {
+			return sm.State{}, nil, ErrGenesisHashDecode
+		}
+		if !bytes.Equal(csGenDoc.Sha256Checksum, decodedOperatorGenesisHash) {
+			return sm.State{}, nil, ErrPassedGenesisHashMismatch
+		}
+	}
+
+	if len(genDocHash) == 0 {
+		// Save the genDoc hash in the store if it doesn't already exist for future verification
+		if err = stateDB.SetSync(genesisDocHashKey, csGenDoc.Sha256Checksum); err != nil {
+			return sm.State{}, nil, ErrSaveGenesisDocHash{Err: err}
+		}
+	} else {
+		if !bytes.Equal(genDocHash, csGenDoc.Sha256Checksum) {
+			return sm.State{}, nil, ErrLoadedGenesisDocHashMismatch
+		}
+	}
+
+	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
+		DiscardABCIResponses: false,
+	})
+
+	state, err := stateStore.LoadFromDBOrGenesisDoc(csGenDoc.GenesisDoc)
+	if err != nil {
+		return sm.State{}, nil, err
+	}
+
+	return state, csGenDoc.GenesisDoc, nil
+}
 
 // LoadStateFromDBOrGenesisDocProvider attempts to load the state from the
 // database, or creates one using the given genesisDocProvider. On success this also
 // returns the genesis doc loaded through the given provider.
+// Note that if you don't have a version of the key layout set in your DB already,
+// and no config is passed, it will default to v1.
 func LoadStateFromDBOrGenesisDocProvider(
 	stateDB dbm.DB,
 	genesisDocProvider GenesisDocProvider,
+	operatorGenesisHashHex string,
 ) (sm.State, *types.GenesisDoc, error) {
-	// Get genesis doc
-	genDoc, err := loadGenesisDoc(stateDB)
-	if err != nil {
-		genDoc, err = genesisDocProvider()
-		if err != nil {
-			return sm.State{}, nil, err
-		}
-
-		err = genDoc.ValidateAndComplete()
-		if err != nil {
-			return sm.State{}, nil, fmt.Errorf("error in genesis doc: %w", err)
-		}
-		// save genesis doc to prevent a certain class of user errors (e.g. when it
-		// was changed, accidentally or not). Also good for audit trail.
-		if err := saveGenesisDoc(stateDB, genDoc); err != nil {
-			return sm.State{}, nil, err
-		}
-	}
-	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
-	state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
-	if err != nil {
-		return sm.State{}, nil, err
-	}
-	return state, genDoc, nil
+	return LoadStateFromDBOrGenesisDocProviderWithConfig(stateDB, genesisDocProvider, operatorGenesisHashHex, nil)
 }
 
 // panics if failed to unmarshal bytes

--- a/rpc/test/helpers.go
+++ b/rpc/test/helpers.go
@@ -175,7 +175,7 @@ func NewTendermint(app abci.Application, opts *Options) *nm.Node {
 	if err != nil {
 		panic(err)
 	}
-	node, err := nm.NewNode(config, pv, nodeKey, papp,
+	node, err := nm.NewNode(context.Background(), config, pv, nodeKey, papp,
 		nm.DefaultGenesisDocProviderFunc(config),
 		cfg.DefaultDBProvider,
 		nm.DefaultMetricsProvider(config.Instrumentation),

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -56,7 +56,7 @@ func BenchmarkLoadValidators(b *testing.B) {
 	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
 		DiscardABCIResponses: false,
 	})
-	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -1,13 +1,10 @@
 package state_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	dbm "github.com/cometbft/cometbft-db"
 
 	cmtrand "github.com/cometbft/cometbft/libs/rand"
 	sm "github.com/cometbft/cometbft/state"
@@ -31,12 +28,7 @@ func TestTxFilter(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		stateDB, err := dbm.NewDB("state", "memdb", os.TempDir())
-		require.NoError(t, err)
-		stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-			DiscardABCIResponses: false,
-		})
-		state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
+		state, err := sm.MakeGenesisState(genDoc)
 		require.NoError(t, err)
 
 		f := sm.TxPreCheck(state)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -64,11 +64,7 @@ func makeStateAndBlockStore() (sm.State, *BlockStore, cleanupFunc) {
 	// blockDB := dbm.NewDebugDB("blockDB", dbm.NewMemDB())
 	// stateDB := dbm.NewDebugDB("stateDB", dbm.NewMemDB())
 	blockDB := dbm.NewMemDB()
-	stateDB := dbm.NewMemDB()
-	stateStore := sm.NewStore(stateDB, sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
-	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
 	if err != nil {
 		panic(fmt.Errorf("error constructing state from genesis file: %w", err))
 	}
@@ -469,10 +465,7 @@ func TestLoadBlockExtendedCommit(t *testing.T) {
 func TestLoadBaseMeta(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
 	defer os.RemoveAll(config.RootDir)
-	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
-	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
 	require.NoError(t, err)
 	bs := NewBlockStore(dbm.NewMemDB())
 
@@ -547,10 +540,7 @@ func TestLoadBlockPart(t *testing.T) {
 func TestPruneBlocks(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
 	defer os.RemoveAll(config.RootDir)
-	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
-	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
 	require.NoError(t, err)
 	db := dbm.NewMemDB()
 	bs := NewBlockStore(db)
@@ -689,10 +679,7 @@ func TestLoadBlockMeta(t *testing.T) {
 func TestLoadBlockMetaByHash(t *testing.T) {
 	config := test.ResetTestRoot("blockchain_reactor_test")
 	defer os.RemoveAll(config.RootDir)
-	stateStore := sm.NewStore(dbm.NewMemDB(), sm.StoreOptions{
-		DiscardABCIResponses: false,
-	})
-	state, err := stateStore.LoadFromDBOrGenesisFile(config.GenesisFile())
+	state, err := sm.MakeGenesisStateFromFile(config.GenesisFile())
 	require.NoError(t, err)
 	bs := NewBlockStore(dbm.NewMemDB())
 

--- a/test/e2e/node/main.go
+++ b/test/e2e/node/main.go
@@ -132,7 +132,8 @@ func startNode(cfg *Config) error {
 		nodeLogger.Info("Using default (synchronized) local client creator")
 	}
 
-	n, err := node.NewNode(cmtcfg,
+	n, err := node.NewNode(context.Background(),
+		cmtcfg,
 		privval.LoadOrGenFilePV(cmtcfg.PrivValidatorKeyFile(), cmtcfg.PrivValidatorStateFile()),
 		nodeKey,
 		clientCreator,


### PR DESCRIPTION
This avoids saving the genesisDoc to database.
When using goleveldb and ~4GiB+ genesis files, it causes a panic during snappy encoding (panic: snappy: decoded block is too large).

refs akash-network/support#280

ports:
- https://github.com/cometbft/cometbft/pull/1017
- https://github.com/cometbft/cometbft/pull/1293