### PR TITLE
crypto/tmhash: add tests for ValidateSHA256

### DIFF
--- a/crypto/tmhash/hash_test.go
+++ b/crypto/tmhash/hash_test.go
@@ -2,6 +2,7 @@ package tmhash_test
 
 import (
 	"crypto/sha256"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,4 +46,109 @@ func TestHashTruncated(t *testing.T) {
 
 	assert.Equal(t, bz, bz2)
 	assert.Equal(t, bz, bz3)
+}
+
+func TestValidateSHA256(t *testing.T) {
+	// Valid 64-character lowercase hex string
+	validLower := strings.Repeat("a1b2c3d4", 8) // 64 chars
+
+	// Valid 64-character uppercase hex string
+	validUpper := strings.Repeat("A1B2C3D4", 8) // 64 chars
+
+	// Valid 64-character mixed case hex string
+	validMixed := "aAbBcCdDeEfF0123456789aAbBcCdDeEfF0123456789aAbBcCdDeEfF01234567"
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid lowercase hex",
+			input:   validLower,
+			wantErr: false,
+		},
+		{
+			name:    "valid uppercase hex",
+			input:   validUpper,
+			wantErr: false,
+		},
+		{
+			name:    "valid mixed case hex",
+			input:   validMixed,
+			wantErr: false,
+		},
+		{
+			name:    "valid all zeros",
+			input:   strings.Repeat("0", 64),
+			wantErr: false,
+		},
+		{
+			name:    "valid all f's",
+			input:   strings.Repeat("f", 64),
+			wantErr: false,
+		},
+		{
+			name:    "too short - 63 chars",
+			input:   strings.Repeat("a", 63),
+			wantErr: true,
+			errMsg:  "expected 64 characters, but have 63",
+		},
+		{
+			name:    "too long - 65 chars",
+			input:   strings.Repeat("a", 65),
+			wantErr: true,
+			errMsg:  "expected 64 characters, but have 65",
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+			errMsg:  "expected 64 characters, but have 0",
+		},
+		{
+			name:    "invalid char g in middle",
+			input:   strings.Repeat("a", 31) + "g" + strings.Repeat("a", 32),
+			wantErr: true,
+			errMsg:  "contains non-hexadecimal characters",
+		},
+		{
+			name:    "invalid char z at start",
+			input:   "z" + strings.Repeat("a", 63),
+			wantErr: true,
+			errMsg:  "contains non-hexadecimal characters",
+		},
+		{
+			name:    "space in middle",
+			input:   strings.Repeat("a", 32) + " " + strings.Repeat("a", 31),
+			wantErr: true,
+			errMsg:  "contains non-hexadecimal characters",
+		},
+		{
+			name:    "special character",
+			input:   strings.Repeat("a", 63) + "!",
+			wantErr: true,
+			errMsg:  "contains non-hexadecimal characters",
+		},
+		{
+			name:    "newline character",
+			input:   strings.Repeat("a", 63) + "\n",
+			wantErr: true,
+			errMsg:  "contains non-hexadecimal characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tmhash.ValidateSHA256(tt.input)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION

## Summary

  Add comprehensive test coverage for `ValidateSHA256` function which is used during node startup to validate genesis document checksums.

  ## Test Cases

  - Valid hex strings (lowercase, uppercase, mixed case)
  - Length validation (too short, too long, empty string)
  - Invalid character detection (non-hex chars, spaces, special chars)

  ## Why

  This function is called in `node/setup.go:612` to validate genesis checksums during node initialization. Test coverage ensures:
  - Security: Invalid hashes are properly rejected
  - Reliability: Valid hashes are correctly accepted

  ## Test Results

  === RUN   TestValidateSHA256
  --- PASS: TestValidateSHA256 (0.00s)
      --- PASS: TestValidateSHA256/valid_lowercase_hex
      --- PASS: TestValidateSHA256/valid_uppercase_hex
      --- PASS: TestValidateSHA256/valid_mixed_case_hex
      --- PASS: TestValidateSHA256/valid_all_zeros
      --- PASS: TestValidateSHA256/valid_all_f's
      --- PASS: TestValidateSHA256/too_short_-63_chars
      --- PASS: TestValidateSHA256/too_long-_65_chars
      --- PASS: TestValidateSHA256/empty_string
      --- PASS: TestValidateSHA256/invalid_char_g_in_middle
      --- PASS: TestValidateSHA256/invalid_char_z_at_start
      --- PASS: TestValidateSHA256/space_in_middle
      --- PASS: TestValidateSHA256/special_character
      --- PASS: TestValidateSHA256/newline_character
  PASS